### PR TITLE
連続送信モードの修正

### DIFF
--- a/MotionDataVerification/Assets/_PremaidAI/RemoteController/Scripts/PreMaidPoseController.cs
+++ b/MotionDataVerification/Assets/_PremaidAI/RemoteController/Scripts/PreMaidPoseController.cs
@@ -16,7 +16,7 @@ namespace PreMaid.RemoteController
 
 
         //何秒ごとにポーズ指定するか
-        private float _poseProcessDelay = 0.02f;
+        private float _poseProcessDelay = 0.1f;
 
         private float _timer = 0.0f;
 
@@ -61,7 +61,7 @@ namespace PreMaid.RemoteController
                 _timer += Time.deltaTime;
                 if (_timer > _poseProcessDelay)
                 {
-                    _controller.ApplyPose();
+                    _controller.ApplyPoseAllServos();
                     _timer -= _poseProcessDelay;
                 }
             }


### PR DESCRIPTION
- 送信頻度が多く、ロスが多くなって遅延の原因になっていたので頻度を下げ遅延回避
- 連続送信モード時のサーボの更新が`現在の値を送信`ボタンを押した時の関数と違う為修正